### PR TITLE
return more than 10 search results; fix environment variable naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@ Primarily, this is used to back up Kibana dashboards that are stored in ElasticS
 
 ## Requirements
 
-These pip packages are required:
-
-* `pip install requests`
-* `pip install boto`
-* `pip install fabric`
+* `pip install -r requirements.txt`
 
 ## Configuration
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -196,9 +196,7 @@ def backup():
     dashboard_dump = _get_dashboards()
 
     backup_paths = []
-    backup_paths.append(_get_backup_key("%A")) # day of week
-    backup_paths.append(_get_backup_key("%B")) # month of year
-    backup_paths.append(_get_backup_key('today')) # today!
+    backup_paths.append(_get_backup_key("%Y-%m-%d__%H-%M")) # timestamp
 
     for key_path in backup_paths:
         print 'Uploading backup to Amazon S3 bucket %s/%s' % (BUCKET_NAME, key_path)

--- a/fabfile.py
+++ b/fabfile.py
@@ -17,8 +17,8 @@ import requests
 
 from fabric.api import *
 
-ELASTIC_SEARCH_HOST = os.environ.get('KIBANA_HOST', 'localhost')
-ELASTIC_SEARCH_PORT = os.environ.get('KIBANA_PORT', 9200)
+ELASTIC_SEARCH_HOST = os.environ.get('ELASTIC_SEARCH_HOST', 'localhost')
+ELASTIC_SEARCH_PORT = os.environ.get('ELASTIC_SEARCH_PORT', 9200)
 
 ###############
 # Helpers
@@ -29,7 +29,7 @@ def _get_s3_bucket_vars():
     PATH_PREFIX = os.environ['KIBANA_PREFIX']
 
 def _es_url(path):
-    return 'http://{0}:{1}/{2}'.format(ELASTIC_SEARCH_HOST, ELASTIC_SEARCH_PORT, path)
+    return 'http://{0}:{1}{2}'.format(ELASTIC_SEARCH_HOST, ELASTIC_SEARCH_PORT, path)
 
 def _get_boto_connection():
     return boto.connect_s3()
@@ -46,7 +46,7 @@ def _get_time_string(format):
 
 def _get_dashboards():
     """Query dashboards stored in ElasticSearch"""
-    return requests.get(_es_url('/kibana-int/dashboard/_search?q=*')).text
+    return requests.get(_es_url('/kibana-int/dashboard/_search?q=*&size=1000')).text
 
 def _get_dashboard(id):
     """Query dashboard by name/id in ElasticSearch"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests==2.8.1
+boto==2.38.0
+fabric==1.10.2
+python-dateutil==2.4.2


### PR DESCRIPTION
This pull request fixes the following:

- environment variable was not consistent with the README. 
- urls has one `/` too much
- search results returned the default of 10 dashboards - which is (for our use case) not enough. (fixes #2 )
